### PR TITLE
[ES-2237] For the first capture the previousHash should be the SHA256 hash of an empty UTF-8 string

### DIFF
--- a/react-secure-biometric-interface-integrator/package.json
+++ b/react-secure-biometric-interface-integrator/package.json
@@ -30,6 +30,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/crypto-js": "^4.2.2",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.25",
     "@types/react": "^18.2.0",
@@ -38,6 +39,7 @@
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
+    "crypto-js": "^4.2.0",
     "css-loader": "^6.7.3",
     "fs": "^0.0.1-security",
     "https-browserify": "^1.0.0",
@@ -67,6 +69,7 @@
   },
   "peerDependencies": {
     "axios": "^1.4.0",
+    "crypto-js": "^4.2.0",
     "jose": "^4.14.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/react-secure-biometric-interface-integrator/src/lib/service/SbiService.tsx
+++ b/react-secure-biometric-interface-integrator/src/lib/service/SbiService.tsx
@@ -5,6 +5,7 @@
  */
 
 import axios from "axios";
+import crypto from "crypto";
 import { localStorageService } from "./";
 import * as jose from "jose";
 import { BioType, ISbiEnv, IDeviceInfo } from "../models";
@@ -36,6 +37,7 @@ const defaultTillPort = 4600;
 
 class SbiService {
   esignetConfig!: ISbiEnv;
+  private previousHash: string | null = null;
 
   constructor(
     esignetConfig: ISbiEnv = {
@@ -101,6 +103,13 @@ class SbiService {
         break;
     }
 
+    let previousHashValue: string;
+    if (!this.previousHash || this.previousHash.trim().length === 0) {
+      previousHashValue = crypto.createHash("sha256").update("").digest("hex");
+    } else {
+      previousHashValue = this.previousHash;
+    }
+
     let request = {
       env: this.esignetConfig.env,
       purpose,
@@ -117,7 +126,7 @@ class SbiService {
           requestedScore, // from configuration
           deviceId, // from discovery
           deviceSubId: 0, //Set as 0, not required for Auth capture.
-          previousHash: "", // empty string
+          previousHash: previousHashValue, // calculated sha256 hash of empty string
         },
       ],
       customOpts: null,
@@ -134,6 +143,10 @@ class SbiService {
       },
       timeout: this.esignetConfig.captureTimeout * 1000,
     });
+
+    if (response?.data?.biometrics?.[0]?.hash) {
+      this.previousHash = response.data.biometrics[0].hash;
+    }
 
     return response?.data;
   };

--- a/react-secure-biometric-interface-integrator/src/lib/service/SbiService.tsx
+++ b/react-secure-biometric-interface-integrator/src/lib/service/SbiService.tsx
@@ -5,7 +5,7 @@
  */
 
 import axios from "axios";
-import crypto from "crypto";
+import cryptoJs from "crypto-js"
 import { localStorageService } from "./";
 import * as jose from "jose";
 import { BioType, ISbiEnv, IDeviceInfo } from "../models";
@@ -105,7 +105,7 @@ class SbiService {
 
     let previousHashValue: string;
     if (!this.previousHash || this.previousHash.trim().length === 0) {
-      previousHashValue = crypto.createHash("sha256").update("").digest("hex");
+      previousHashValue = cryptoJs.SHA256("").toString();
     } else {
       previousHashValue = this.previousHash;
     }

--- a/secure-biometric-interface-integrator/package.json
+++ b/secure-biometric-interface-integrator/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "crypto-js": "^4.2.0",
     "i18next": "^22.5.0",
     "jose": "^4.14.3"
   }

--- a/secure-biometric-interface-integrator/utility/sbiservice.js
+++ b/secure-biometric-interface-integrator/utility/sbiservice.js
@@ -7,6 +7,7 @@
 import axios from "axios";
 import { localStorageService } from "./localstorage";
 import * as jose from "jose";
+import crypto from "crypto";
 
 const {
   addDeviceInfos,
@@ -50,6 +51,7 @@ const BioType = {
 
 class SbiService {
   sbiConfig;
+  previousHash = null;
 
   constructor(sbiConfig) {
     this.sbiConfig = {
@@ -153,6 +155,13 @@ class SbiService {
         break;
     }
 
+    let previousHashValue;
+    if (!this.previousHash || this.previousHash.trim().length === 0) {
+      previousHashValue = crypto.createHash("sha256").update("").digest("hex");
+    } else {
+      previousHashValue = this.previousHash;
+    }
+
     let request = {
       env: this.sbiConfig.env,
       purpose,
@@ -169,7 +178,7 @@ class SbiService {
           requestedScore, // from configuration
           deviceId, // from discovery
           deviceSubId: "0", //Set as 0, not required for Auth capture.
-          previousHash: "", // empty string
+          previousHash: previousHashValue, // calculated sha256 hash of empty utf-8 string
         },
       ],
       customOpts: null,
@@ -185,6 +194,11 @@ class SbiService {
         "Content-Type": "application/json",
       },
     });
+
+    if (response?.data?.biometrics?.[0]?.hash) {
+      this.previousHash = response.data.biometrics[0].hash;
+    }
+    
     return response?.data;
   };
 

--- a/secure-biometric-interface-integrator/utility/sbiservice.js
+++ b/secure-biometric-interface-integrator/utility/sbiservice.js
@@ -7,7 +7,7 @@
 import axios from "axios";
 import { localStorageService } from "./localstorage";
 import * as jose from "jose";
-import crypto from "crypto";
+import cryptoJs from "crypto-js";
 
 const {
   addDeviceInfos,
@@ -157,7 +157,7 @@ class SbiService {
 
     let previousHashValue;
     if (!this.previousHash || this.previousHash.trim().length === 0) {
-      previousHashValue = crypto.createHash("sha256").update("").digest("hex");
+      previousHashValue = cryptoJs.SHA256("").toString();
     } else {
       previousHashValue = this.previousHash;
     }


### PR DESCRIPTION
For the first capture the previousHash should be the SHA256 hash of an empty UTF-8 string - fixed.