### PR TITLE
[ES-2862] Fixed Required Photo Field Validation issue.

### DIFF
--- a/json-form-builder/src/components/FileUploadComponent.ts
+++ b/json-form-builder/src/components/FileUploadComponent.ts
@@ -64,7 +64,7 @@ export const createFileUploadField = (
                 || { en: "Document Type" },
             placeholder: state.placeholders?.docType || { en: "Select an option" },
             subType: field.subType,
-            required: true,
+            required: field.required,
             disabled: field.disabled
         };
         docTypeFieldEl = createDropdownField(state, docTypeField, true);
@@ -115,7 +115,7 @@ export const createFileUploadField = (
     podLabel.innerHTML = getLabelText(state, {
         id: `${field.id}_proof`,
         controlType: "textbox",
-        required: true,
+        required: field.required,
         labelName: state.labels?.proofOfDoc
             || { en: "Proof Of Document" }
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The required status of document type selection and proof of document fields in file uploads now correctly respects individual form configuration settings instead of always being required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->