### PR TITLE
[#2048] Added File Type Validation Based on MIME Type in Json-Form-Builder.

### DIFF
--- a/json-form-builder/src/components/FileUploadComponent.ts
+++ b/json-form-builder/src/components/FileUploadComponent.ts
@@ -9,7 +9,9 @@ import {
     getLabelText,
     emptyInvalidFn,
     getAcceptString,
-    mimeToLabel
+    mimeToLabel,
+    detectMimeFromMagicBytes,
+    UNKNOWN_MIME_TYPE
 } from "../utils/utils";
 import { uploadIconSvg, trashIconSvg, fileIconSvg } from "../utils/icons";
 import { createStringField } from "./TextInputComponent";
@@ -321,7 +323,18 @@ export const createFileUploadField = (
             return;
         }
 
-        if (!allowedTypes.includes(file.type)) {
+        // Validate file type using magic bytes (content-based, not extension-based).
+        // If the type is recognised, it is used as the source of truth.
+        // If unrecognised or detection fails, fall back to the browser's extension-based file.type.
+        let effectiveMime: string;
+        try {
+            const detectedMime = await detectMimeFromMagicBytes(file);
+            effectiveMime = detectedMime !== UNKNOWN_MIME_TYPE ? detectedMime : file.type;
+        } catch {
+            effectiveMime = file.type;
+        }
+
+        if (!allowedTypes.includes(effectiveMime)) {
             appendError(errorContainer, `Unsupported file type: ${file.name}`);
             return;
         }

--- a/json-form-builder/src/utils/utils.ts
+++ b/json-form-builder/src/utils/utils.ts
@@ -683,6 +683,43 @@ const emptyInvalidFn = (
   };
 };
 
+/**
+ * Known file magic byte signatures mapped to their MIME types.
+ */
+const MAGIC_BYTE_SIGNATURES: ReadonlyArray<{ readonly hex: string; readonly mime: string }> = [
+  { hex: "89504E47", mime: "image/png" },
+  { hex: "FFD8FF",   mime: "image/jpeg" },
+  { hex: "25504446", mime: "application/pdf" },
+];
+
+const UNKNOWN_MIME_TYPE = "application/octet-stream";
+
+/**
+ * Detects the MIME type of a file by reading its magic bytes (first 12 bytes).
+ * Returns UNKNOWN_MIME_TYPE if the signature is not recognised.
+ * This is content-based detection — independent of the file name or extension.
+ */
+const detectMimeFromMagicBytes = async (file: File): Promise<string> => {
+  const buffer = await file.slice(0, 12).arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  const hex = Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, "0").toUpperCase())
+    .join("");
+
+  // WebP: RIFF (4 bytes) + file size (4 bytes) + WEBP (4 bytes)
+  const RIFF_SIGNATURE = "52494646";
+  const WEBP_SIGNATURE = "57454250";
+  if (hex.startsWith(RIFF_SIGNATURE) && hex.substring(16, 24) === WEBP_SIGNATURE) {
+    return "image/webp";
+  }
+
+  for (const { hex: sig, mime } of MAGIC_BYTE_SIGNATURES) {
+    if (hex.startsWith(sig)) return mime;
+  }
+
+  return UNKNOWN_MIME_TYPE;
+};
+
 // Convert MIME → clean extension
 const mimeToExtension = (mimeType: string): string => {
   const ext = mime.extension(mimeType);
@@ -738,5 +775,7 @@ export {
   getAcceptString,
   mimeToLabel,
   isSubTypeField,
-  triggerRefreshLabels
+  triggerRefreshLabels,
+  detectMimeFromMagicBytes,
+  UNKNOWN_MIME_TYPE
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploaded files are now validated using content-based MIME detection, improving recognition for formats like PNG, JPEG, PDF, and WebP.
  * When the detected content type is unknown, validation falls back to the browser-provided file type more consistently.

* **Bug Fixes**
  * Reduced the chance of accepting unsupported or incorrect file types that previously relied only on metadata rather than actual file contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->